### PR TITLE
Simplified issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,15 +7,11 @@ assignees: ''
 
 ---
 
-### FOLLOW THESE INSTRUCTIONS CAREFULLY
+Thanks for contacting us! Please read and follow these instructions carefully, then delete this introductory text to keep your issue easy to read. Note that the issue tracker is NOT the place for usage questions and technical assistance; post those at [Discourse](https://discourse.holoviz.org) instead. Issues without the required information below may be closed immediately.
 
-*ISSUES THAT DO NOT CONTAIN NECESSARY INFORMATION MAY BE CLOSED, IMMEDIATELY*
 
-The issue tracker is NOT the place for general support. For usage questions and technical assistance, ask us on [Discourse](https://discourse.holoviz.org).
-
-For defects or deficiencies, please provide *ALL OF THE FOLLOWING*:
-
-#### ALL software version info (this library, plus any other relevant software, e.g. bokeh, python, notebook, OS, browser, etc)
+#### ALL software version info
+(this library, plus any other relevant software, e.g. bokeh, python, notebook, OS, browser, etc)
 
 #### Description of expected behavior and the observed behavior
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: HoloViz Discourse
+    url: https://discourse.holoviz.org/
+    about: Discussions and questions about using HoloViz tools

--- a/.github/ISSUE_TEMPLATE/custom-issue.md
+++ b/.github/ISSUE_TEMPLATE/custom-issue.md
@@ -7,5 +7,4 @@ assignees: ''
 
 ---
 
-
-Before creating a custom issue, you might want to discuss with us on [Discourse](https://discourse.holoviz.org).
+Stop! Github issues are for feature requests and bug reports only; just about anything else should be opened on [Discourse](https://discourse.holoviz.org) instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,20 +7,17 @@ assignees: ''
 
 ---
 
-### FOLLOW THESE INSTRUCTIONS CAREFULLY
+Thanks for contacting us! Please read and follow these instructions carefully, then delete this introductory text to keep your issue easy to read. Note that the issue tracker is NOT the place for usage questions and technical assistance; post those at [Discourse](https://discourse.holoviz.org) instead. Issues without the required information below may be closed immediately.
 
-*ISSUES THAT DO NOT CONTAIN NECESSARY INFORMATION MAY BE CLOSED, IMMEDIATELY*
 
-The issue tracker is NOT the place for general support. For usage questions and technical assistance, ask us on [Discourse](https://discourse.holoviz.org).
-
-**Is your feature request related to a problem? Please describe.**
+#### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+#### Additional context
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
- Tell people to delete the explanatory text (otherwise reports are very noisy!)
- Use same formatting for bug reports and feature requests
- Tell people not to open custom issues (which they can ignore, but at least we told them!)