### PR TITLE
Revert "Add default bug/feature labels to issue templates (using Panel's style of bug/feature labels)"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: TRIAGE, "type: bug"
+labels: TRIAGE
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: TRIAGE, "type: feature"
+labels: TRIAGE
 assignees: ''
 
 ---


### PR DESCRIPTION
Reverts holoviz/.github#4

After I merged #4, I found that the 'bug' and 'feature' options disappeared from panel's create new issue flow :(