### PR TITLE
Add default bug/feature labels to issue templates (using Panel's style of bug/feature labels).

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: TRIAGE, "type: bug"
+labels: TRIAGE, bug-report
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: TRIAGE
+labels: TRIAGE, "type: bug"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: TRIAGE
+labels: TRIAGE, "type: feature"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: TRIAGE, "type: feature"
+labels: TRIAGE, feature-request
 assignees: ''
 
 ---


### PR DESCRIPTION
Based on step 7 from https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository. 

However, this does not work: when I merged (#4), "bug" and "feature" templates disappeared from panel's create issue workflow :(

Who wants to guess what's wrong?