### PR TITLE
Try to prompt for better info from lab users.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ Thanks for contacting us! Please read and follow these instructions carefully, t
 
 
 #### ALL software version info
-(this library, plus any other relevant software, e.g. bokeh, python, notebook, OS, browser, etc)
+(this library, plus any other relevant software, e.g. bokeh, python, jupyter notebook or lab plus [extensions](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html#using-the-terminal), OS, browser, etc)
 
 #### Description of expected behavior and the observed behavior
 
@@ -23,5 +23,6 @@ Thanks for contacting us! Please read and follow these instructions carefully, t
 ```
 
 #### Stack traceback and/or browser JavaScript console output
+(If using jupyter lab, check the log console)
 
 #### Screenshots or screencasts of the bug in action


### PR DESCRIPTION
First, I am not sure if this is a good idea to apply across all holoviz projects.

Second, I am not sure if this makes it easy for people to understand what info to add if they are a lab user.

The problem I'm trying to solve is that for e.g. panel, you often want to know if someone is using jupyter notebook or lab. And if using lab, you want to know if they have the relevant extensions installed for what they are trying to do and what versions.

(In general, it would be better if we could provide a way for people to generate bug report info...)